### PR TITLE
Easy API for cross account pull and push and auth access via account ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `pull_accounts` and `push_accounts` variables for providing a
+  convenient way of managing cross account pull and push access.
+
 ## [0.5.0]
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ grant cross account pull or push access to the repository.
 
 - **Additional Features**:
   Grant pull access to AWS identities (cross account),
-  Grant pull&push access to AWS identities (crosss account)
+  Grant pull & push access to AWS identities (cross account),
+  Grant pull & push & ECR authentication access to AWS accounts (cross account)
 
 - *Features not yet implemented*:
   Easy lifecycle rule setup
@@ -149,7 +150,6 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   A list of dependencies. Any object can be _assigned_ to this list to define a hidden external dependency.
 
-
 #### Main Resource Configuration
 
 - **`name`**: **(Required `string`, Forces new resource)**
@@ -193,6 +193,18 @@ See [variables.tf] and [examples/] for details and use-cases.
 - **`push_identities`**: *(Optional `list(string)`)*
 
   List of AWS identity identifiers to grant cross account push access to.
+  Default is `[]`.
+
+- **`pull_accounts`**: *(Optional `list(string)`)*
+
+  List of AWS Account IDs to grant cross account pull access and
+  authentication access with ECR to.
+  Default is `[]`.
+
+- **`push_accounts`**: *(Optional `list(string)`)*
+
+  List of AWS Account IDs to grant cross account push access and
+  authentication access with ECR to.
   Default is `[]`.
 
 #### [`policy_statements`](#main-resource-configuration) Object Arguments

--- a/variables.tf
+++ b/variables.tf
@@ -61,13 +61,25 @@ variable "lifecycle_policy_rules" {
 
 variable "pull_identities" {
   type        = list(string)
-  description = "(Optional) List of AWS identity identifiers to grant cross account pull access to"
+  description = "(Optional) List of AWS identity identifiers to grant cross account pull access to."
   default     = []
 }
 
 variable "push_identities" {
   type        = list(string)
-  description = "(Optional) List of AWS identity identifiers to grant cross account pull and push access to"
+  description = "(Optional) List of AWS identity identifiers to grant cross account push access to."
+  default     = []
+}
+
+variable "pull_accounts" {
+  type        = list(string)
+  description = "(Optional) List of AWS Account IDs to grant cross account pull access to."
+  default     = []
+}
+
+variable "push_accounts" {
+  type        = list(string)
+  description = "(Optional) List of AWS Account IDs to grant cross account push access to."
   default     = []
 }
 


### PR DESCRIPTION
Allows for easy cross-account on- and offboarding via principals.

```hcl
module "resource" {
  source  = "mineiros-io/ecr/aws"
  version = "~> 0.4.0"

  pull_accounts = [
    "1234567890", # Staging
    "1234567890", # Production
    ....
  ]

  name = "example"
}
```